### PR TITLE
avoid dragging in gettext's libintl.h / libintl

### DIFF
--- a/configure
+++ b/configure
@@ -3893,51 +3893,6 @@ $as_echo "#define HAVE_PROGRAM_INVOCATION_SHORT_NAME 1" >>confdefs.h
 
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for gettext in -lintl" >&5
-$as_echo_n "checking for gettext in -lintl... " >&6; }
-if ${ac_cv_lib_intl_gettext+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lintl  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char gettext ();
-int
-main ()
-{
-return gettext ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_intl_gettext=yes
-else
-  ac_cv_lib_intl_gettext=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_intl_gettext" >&5
-$as_echo "$ac_cv_lib_intl_gettext" >&6; }
-if test "x$ac_cv_lib_intl_gettext" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBINTL 1
-_ACEOF
-
-  LIBS="-lintl $LIBS"
-
-fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for nanosleep in -lposix4" >&5
 $as_echo_n "checking for nanosleep in -lposix4... " >&6; }
 if ${ac_cv_lib_posix4_nanosleep+:} false; then :

--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,6 @@ LOCAL_CHECK_FUNC([stpcpy], [#include <string.h>])
 LOCAL_CHECK_FUNC([strsep], [#include <string.h>])
 LOCAL_CHECK_VAR([program_invocation_name], [#include <errno.h>])
 LOCAL_CHECK_VAR([program_invocation_short_name], [#include <errno.h>])
-AC_CHECK_LIB([intl], [gettext])
 AC_CHECK_LIB([posix4], [nanosleep])
 
 # These two macros are taken from GCC's config/acx.m4.

--- a/include/libintl.h
+++ b/include/libintl.h
@@ -1,5 +1,5 @@
 #ifdef HAVE_LIBINTL_H
-#include_next <libintl.h>
+#include "../intl/libintl.h"
 #endif
 
 #ifndef _


### PR DESCRIPTION
modify configure.ac and configure to make sure that we don't need to revisit in
case autoconf is run in localedef subdirectory

Signed-off-by: Andreas Müller schnitzeltony@googlemail.com
