### PR TITLE
Update config.guess to Support PPC64 LE

### DIFF
--- a/config.guess
+++ b/config.guess
@@ -876,6 +876,9 @@ EOF
     ppc64:Linux:*:*)
 	echo powerpc64-unknown-linux-gnu
 	exit 0 ;;
+    ppc64le:Linux:*:*)
+	echo powerpc64le-unknown-linux-gnu
+	exit 0 ;;
     alpha:Linux:*:*)
 	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo` in
 	  EV5)   UNAME_MACHINE=alphaev5 ;;


### PR DESCRIPTION
IBM created a new version of the Power line that works in both Big Endian and Little Endian modes.  This change is to add ppc64le to your config guesser.
